### PR TITLE
create security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+# jq Security Policy
+
+To report a security issue, please email $EMAIL with a description of the issue, the steps you took to create the issue, affected versions, and if known, mitigations for the issue. Our vulnerability management team will acknowledge receiving your email within 5 working days. This project follows a 90 day disclosure timeline.


### PR DESCRIPTION
Security Policy based on [OpenSSF's example](https://github.com/ossf/oss-vulnerability-guide/blob/main/templates/security_policies/email_intake.md).

This would help security researchers who want to privately report vulnerabilities to jq like https://github.com/jqlang/jq/issues/2496

Please take out whatever does not apply to your project and replace $EMAIL. The last two sentences are fairly standard (and encouraged), but *could* be removed.